### PR TITLE
Send the magnetic heading in monitoring data

### DIFF
--- a/index.js
+++ b/index.js
@@ -871,6 +871,9 @@ module.exports = function(app) {
         sog: metersPerSecondToKnots(getKeyValue('navigation.speedOverGround', 60)),
         cog: radiantToDegrees(getKeyValue('navigation.courseOverGroundTrue', 60)),
         heading: radiantToDegrees(getKeyValue('navigation.headingTrue', 60)),
+        // Most NMEA 2000 networks publish only a magnetic heading; send it
+        // under its own name.
+        headingMagnetic: radiantToDegrees(getKeyValue('navigation.headingMagnetic', 60)),
         anchor: {
           position: getKeyValue('navigation.anchor.position', 60),
           radius: getKeyValue('navigation.anchor.maxRadius', 60)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-saillogger",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Maintenance-free, fully automated logbook and remote boat monitoring solution",
   "main": "index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary
- The monitoring data now carries `headingMagnetic` (from `navigation.headingMagnetic`, same 60-second freshness as `heading`) beside `heading`.
- Most NMEA 2000 networks publish only a magnetic heading, so boats without `navigation.headingTrue` sent no heading at all.
- Version 5.2.0 -> 5.3.0.

## Test plan
- `npm test` passes.
- Verify on a boat that publishes only `navigation.headingMagnetic`.